### PR TITLE
Update `examples/simple_rag/README.md` to verify the installation of `lxml`

### DIFF
--- a/examples/simple_rag/README.md
+++ b/examples/simple_rag/README.md
@@ -37,7 +37,7 @@ This is a simple example RAG application to showcase how one can configure and u
     export NVIDIA_API_KEY=<YOUR API KEY HERE>
     ```
 
-    Verify whether `lxml` is installed in your current environment. If it’s not found, simply install it using `pip install lxml`. Next, execute the `bootstrap_milvus.sh` script as illustrated below.
+    Verify whether `lxml` is installed in your current environment. If it’s not installed, simply install it using `pip install lxml`. Next, execute the `bootstrap_milvus.sh` script as illustrated below.
     ```bash
     source .venv/bin/activate
     examples/simple_rag/ingestion/bootstrap_milvus.sh

--- a/examples/simple_rag/README.md
+++ b/examples/simple_rag/README.md
@@ -37,7 +37,7 @@ This is a simple example RAG application to showcase how one can configure and u
     export NVIDIA_API_KEY=<YOUR API KEY HERE>
     ```
 
-    Verify whether `lxml` is installed in your current environment. If it’s not installed, simply install it using `pip install lxml`. Next, execute the `bootstrap_milvus.sh` script as illustrated below.
+    Verify  whether `lxml` is installed in your current environment. If it’s not installed, simply install it using `pip install lxml`. Next, execute the `bootstrap_milvus.sh` script as illustrated below.
     ```bash
     source .venv/bin/activate
     examples/simple_rag/ingestion/bootstrap_milvus.sh

--- a/examples/simple_rag/README.md
+++ b/examples/simple_rag/README.md
@@ -37,7 +37,7 @@ This is a simple example RAG application to showcase how one can configure and u
     export NVIDIA_API_KEY=<YOUR API KEY HERE>
     ```
 
-    Verify  whether `lxml` is installed in your current environment. If it’s not installed, simply install it using `pip install lxml`. Next, execute the `bootstrap_milvus.sh` script as illustrated below.
+    Verify whether `lxml` is installed in your current environment. If it’s not installed, simply install it using `pip install lxml`. Next, execute the `bootstrap_milvus.sh` script as illustrated below.
     ```bash
     source .venv/bin/activate
     examples/simple_rag/ingestion/bootstrap_milvus.sh

--- a/examples/simple_rag/README.md
+++ b/examples/simple_rag/README.md
@@ -37,6 +37,7 @@ This is a simple example RAG application to showcase how one can configure and u
     export NVIDIA_API_KEY=<YOUR API KEY HERE>
     ```
 
+    Verify whether `lxml` is installed in your current environment. If it’s not found, simply install it using `pip install lxml`. Next, execute the `bootstrap_milvus.sh` script as illustrated below.
     ```bash
     source .venv/bin/activate
     examples/simple_rag/ingestion/bootstrap_milvus.sh


### PR DESCRIPTION
`lxml` might be missing from users' local environment if they don't do the whole `uv install` of `AgentIQ` (i.e. installing `AgentIQ` via pypi package). Add an additional step to confirm that `lxml` is installed before moving forward with the `milvus` setup.