### PR TITLE
Fix case where res['categories'] = None

### DIFF
--- a/packages/agentiq_mem0ai/src/aiq/plugins/mem0ai/mem0_editor.py
+++ b/packages/agentiq_mem0ai/src/aiq/plugins/mem0ai/mem0_editor.py
@@ -92,7 +92,7 @@ class Mem0Editor(MemoryEditor):
                 MemoryItem(conversation=res.pop("input", []),
                            user_id=user_id,
                            memory=res["memory"],
-                           tags=res.pop("categories", []),
+                           tags=res.pop("categories", []) or [],
                            metadata=item_meta))
 
         return memories


### PR DESCRIPTION
@mdemoret-nv `res` sometimes contains the `categories` field `=None`

Causing a pydantic validation exception sometimes