### PR TITLE
Groundwork for generating ground truth

### DIFF
--- a/examples/simple/src/aiq_simple/configs/groundtruth_config.yml
+++ b/examples/simple/src/aiq_simple/configs/groundtruth_config.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 general:
   use_uvloop: true
 
@@ -42,6 +41,10 @@ llms:
     model_name: meta/llama-3.1-70b-instruct
     temperature: 0.0
     max_tokens: 1024
+  openai_llm:
+    _type: openai
+    model_name: gpt-4o-mini
+    max_tokens: 1024
 
 embedders:
   nv-embedqa-e5-v5:
@@ -51,7 +54,7 @@ embedders:
 workflow:
   _type: react_agent
   tool_names: [webpage_query, current_datetime]
-  llm_name: nim_llm
+  llm_name: openai_llm
   verbose: true
   retry_parsing_errors: true
   max_retries: 3
@@ -59,6 +62,7 @@ workflow:
 eval:
   general:
     output_dir: ./.tmp/aiq/examples/simple/
+    max_concurrency: 4
     dataset:
       _type: json
       file_path: examples/simple/data/langsmith.json

--- a/examples/simple/src/aiq_simple/configs/groundtruth_config.yml
+++ b/examples/simple/src/aiq_simple/configs/groundtruth_config.yml
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+general:
+  use_uvloop: true
+
+functions:
+  webpage_query:
+    _type: webpage_query
+    webpage_url: https://docs.smith.langchain.com/user_guide
+    description: "Search for information about LangSmith. For any questions about LangSmith, you must use this tool!"
+    embedder_name: nv-embedqa-e5-v5
+  current_datetime:
+    _type: current_datetime
+
+llms:
+  nim_llm:
+    _type: nim
+    model_name: meta/llama-3.1-70b-instruct
+    temperature: 0.0
+  nim_rag_eval_llm:
+    _type: nim
+    model_name: meta/llama-3.3-70b-instruct
+    temperature: 0.0000001
+    top_p: 0.0001
+    max_tokens: 2
+  nim_trajectory_eval_llm:
+    _type: nim
+    model_name: meta/llama-3.1-70b-instruct
+    temperature: 0.0
+    max_tokens: 1024
+
+embedders:
+  nv-embedqa-e5-v5:
+    _type: nim
+    model_name: nvidia/nv-embedqa-e5-v5
+
+workflow:
+  _type: react_agent
+  tool_names: [webpage_query, current_datetime]
+  llm_name: nim_llm
+  verbose: true
+  retry_parsing_errors: true
+  max_retries: 3
+
+eval:
+  general:
+    output_dir: ./.tmp/aiq/examples/simple/
+    dataset:
+      _type: json
+      file_path: examples/simple/data/langsmith.json
+      # file_path: examples/simple/data/simple_questions.json
+
+  evaluators:
+    rag_accuracy:
+      _type: ragas
+      metric: AnswerAccuracy
+      llm_name: nim_rag_eval_llm
+    rag_groundedness:
+      _type: ragas
+      metric: ResponseGroundedness
+      llm_name: nim_rag_eval_llm
+    rag_relevance:
+      _type: ragas
+      metric: ContextRelevance
+      llm_name: nim_rag_eval_llm
+    trajectory_accuracy:
+      _type: trajectory
+      llm_name: nim_trajectory_eval_llm

--- a/src/aiq/cli/commands/evaluate.py
+++ b/src/aiq/cli/commands/evaluate.py
@@ -77,6 +77,13 @@ logger = logging.getLogger(__name__)
     default=1,
     help="Number of repetitions for the evaluation.",
 )
+@click.option(
+    "--generate_ground_truth",
+    is_flag=True,
+    default=False,
+    help="Generate ground truth dataset based on evaluation results. \
+        Can be used with --reps greater than 1 to get the best answer.",
+)
 @click.pass_context
 def eval_command(ctx, **kwargs) -> None:
     """ Evaluate datasets with the specified mechanism"""
@@ -101,6 +108,7 @@ def process_aiq_eval(
     endpoint: str,
     endpoint_timeout: int,
     reps: int,
+    generate_ground_truth: bool,
 ):
     """
     Process the eval command and execute the evaluation. Here the config_file, if provided, is checked for its existence
@@ -127,5 +135,6 @@ def process_aiq_eval(
         endpoint=endpoint,
         endpoint_timeout=endpoint_timeout,
         reps=reps,
+        generate_ground_truth=generate_ground_truth,
     )
     asyncio.run(run_and_evaluate(config))

--- a/src/aiq/eval/config.py
+++ b/src/aiq/eval/config.py
@@ -30,6 +30,7 @@ class EvaluationRunConfig(BaseModel):
     endpoint: str | None  # only used when running the workflow remotely
     endpoint_timeout: int
     reps: int
+    generate_ground_truth: bool
 
 
 class EvaluationRunOutput(BaseModel):
@@ -39,3 +40,4 @@ class EvaluationRunOutput(BaseModel):
     workflow_output_file: Path | None
     evaluator_output_files: list[Path]
     workflow_interrupted: bool
+    generated_ground_truth_file: Path | None

--- a/src/aiq/eval/dataset_handler/dataset_handler.py
+++ b/src/aiq/eval/dataset_handler/dataset_handler.py
@@ -176,13 +176,12 @@ class DatasetHandler:
         if not self.is_structured_input():
             None
 
-            # Extract structured data from EvalInputItems
-            data = [{
-                self.id_key: item.id,
-                self.question_key: item.input_obj,
-                self.answer_key: item.expected_output_obj,
-                self.generated_answer_key: item.output_obj,
-            } for item in eval_input.eval_input_items]
+        # Extract structured data from EvalInputItems
+        data = [{
+            self.id_key: item.id,
+            self.question_key: item.input_obj,
+            self.answer_key: item.expected_output_obj,
+        } for item in eval_input.eval_input_items]
 
         return json.dumps(data, indent=indent, ensure_ascii=False)
 
@@ -219,18 +218,19 @@ class DatasetHandler:
 
         # Create a new EvalInput with original IDs using the best repetitions
         best_eval_items = []
-        for item in original_eval_input.eval_input_items:
-            if item.id in best_reps:
-                original_id = item.id  # Keep the original ID (without _rep)
-
-                best_eval_items.append(
-                    EvalInputItem(
-                        id=original_id,
-                        input_obj=item.input_obj,
-                        expected_output_obj=item.expected_output_obj,
-                        output_obj=None,
-                        expected_trajectory=[],
-                        trajectory=[],
-                    ))
-
+        for id, (rep_id, _) in best_reps.items():
+            # Find the original item using the rep_id
+            for item in original_eval_input.eval_input_items:
+                if item.id == rep_id:  # Match the best rep_id
+                    # Use the generated answer as the ground truth/expected output
+                    best_eval_items.append(
+                        EvalInputItem(
+                            id=id,  # Assign the base ID, without the rep suffix
+                            input_obj=item.input_obj,
+                            expected_output_obj=item.output_obj,
+                            output_obj=None,
+                            expected_trajectory=[],
+                            trajectory=[],
+                        ))
+                    break
         return EvalInput(eval_input_items=best_eval_items)

--- a/src/aiq/eval/evaluate.py
+++ b/src/aiq/eval/evaluate.py
@@ -190,7 +190,7 @@ class EvaluationRun:  # pylint: disable=too-many-public-methods
         if self.generated_ground_truth:
             generated_ground_truth_file = self.eval_config.general.output_dir / "generated_ground_truth.json"
             generated_ground_truth_file.parent.mkdir(parents=True, exist_ok=True)
-            generated_ground_truth = dataset_handler.publish_eval_input(self.generated_ground_truth)
+            generated_ground_truth = dataset_handler.publish_ground_truth(self.generated_ground_truth)
             if generated_ground_truth:
                 with open(generated_ground_truth_file, "w", encoding="utf-8") as f:
                     f.write(generated_ground_truth)


### PR DESCRIPTION
This evaluation option can be used to adjust the ground-truth based on a "golden-workflow config". It can also be used for generating answers for a set of questions (that have no ground-truth). This process trusts the answers provide by the "golden-workflow config"

1. Run "golden" workflow on questions. Multiple repetitions can be used to normalize differences in the generated output.
2. The scores are averaged across multiple evaluators and the rep with the best score is used for creating the ground truth dataset

Sample usage:
1. Run workflow with pre-defined ground truth  (uses llama3 for the workflow)
```
aiq eval --config_file examples/simple/configs/eval_config.yml
```
Average "Answer Accuracy" score: `0.67`

2.  Run workflow with "golden config" and generate (new) ground truth
```
aiq eval --config_file examples/simple/configs/groundtruth_config.yml --reps 2 --generate_ground_truth
```
Groundtruth file: .tmp/aiq/examples/simple/generated_ground_truth.json


3. Re-run workflow with generated ground truth
```
aiq eval --config_file examples/simple/configs/eval_config.yml --dataset .tmp/aiq/examples/simple/generated_ground_truth.json
```
Average "Answer Accuracy" score: `0.83`