### PR TITLE
CI Documentation improvements

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = build
 
 # By default clean and build the html documentation
 # Not cleaning doesn't save any time, and can lead to stale files
-default: clean html
+default: clean linkcheck html
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -20,7 +20,8 @@ clean:
 
 .PHONY: help Makefile
 
-# $(O) is meant as a shortcut for $(SPHINXOPTS).
-html: Makefile
+linkcheck:
 	@$(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+html: Makefile
 	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -j auto --show-traceback --fresh-env --write-all
+SPHINXOPTS    = -j 4 --show-traceback -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
@@ -22,5 +22,5 @@ clean:
 
 # $(O) is meant as a shortcut for $(SPHINXOPTS).
 html: Makefile
-	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@$(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,4 +24,4 @@ linkcheck:
 	@$(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 html: Makefile
-	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,5 +22,5 @@ clean:
 
 # $(O) is meant as a shortcut for $(SPHINXOPTS).
 html: Makefile
-	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@$(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -171,6 +171,7 @@ html_theme = "nvidia_sphinx_theme"
 # documentation.
 
 html_logo = '_static/main_nv_logo_square.png'
+html_title = f'{project} ({version})'
 
 html_theme_options = {
     'collapse_navigation': False,
@@ -283,16 +284,3 @@ def skip_pydantic_special_attrs(app: object, what: str, name: str, obj: "PythonO
 def setup(sphinx):
     # Work-around for for Pydantic docstrings that trigger parsing warnings
     sphinx.connect("autoapi-skip-member", skip_pydantic_special_attrs)
-
-    # Work-around for performance issue with nvidia_sphinx_theme when parallel_read_safe is True
-    import nvidia_sphinx_theme
-
-    orig_setup = nvidia_sphinx_theme.setup
-
-    def work_around_theme_settings(sphinx):
-        theme_settings = orig_setup(sphinx)
-        theme_settings['parallel_read_safe'] = False
-
-        return theme_settings
-
-    nvidia_sphinx_theme.setup = work_around_theme_settings


### PR DESCRIPTION
* Add version number to the documentation title
* Add `-W` flag to `sphinx-build` treating warnings as errors.
* Remove performance hack, instead just set `-j 4` (instead of auto).
* Remove unused `sphinx-build` flags
* `linkcheck` is now it's own make target
