### PR TITLE
Provide a cleaner progress bar when running evaluators in parallel

### DIFF
--- a/src/aiq/eval/evaluate.py
+++ b/src/aiq/eval/evaluate.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel
-from tqdm.asyncio import tqdm
+from tqdm import tqdm
 
 from aiq.data_models.evaluate import EvalConfig
 from aiq.eval.config import EvaluationRunConfig

--- a/src/aiq/eval/evaluate.py
+++ b/src/aiq/eval/evaluate.py
@@ -123,6 +123,10 @@ class EvaluationRun:  # pylint: disable=too-many-public-methods
                 item.output_obj = output
                 item.trajectory = self.intermediate_step_adapter.validate_intermediate_steps(intermediate_steps)
 
+        async def wrapped_run(item: EvalInputItem) -> None:
+            await run_one(item)
+            pbar.update(1)
+
         # if self.config.skip_complete is set skip eval_input_items with a non-empty output_obj
         if self.config.skip_completed_entries:
             eval_input_items = [item for item in self.eval_input.eval_input_items if not item.output_obj]
@@ -131,7 +135,9 @@ class EvaluationRun:  # pylint: disable=too-many-public-methods
                 return
         else:
             eval_input_items = self.eval_input.eval_input_items
-        await tqdm.gather(*[run_one(item) for item in eval_input_items])
+        pbar = tqdm(total=len(eval_input_items), desc="Running workflow")
+        await asyncio.gather(*[wrapped_run(item) for item in eval_input_items])
+        pbar.close()
 
     async def run_workflow(self, session_manager: AIQSessionManager):
         if self.config.endpoint:

--- a/src/aiq/eval/trajectory_evaluator/evaluate.py
+++ b/src/aiq/eval/trajectory_evaluator/evaluate.py
@@ -22,8 +22,10 @@ from langchain_core.tools import BaseTool
 from tqdm.asyncio import tqdm
 
 from aiq.eval.evaluator.evaluator_model import EvalInput
+from aiq.eval.evaluator.evaluator_model import EvalInputItem
 from aiq.eval.evaluator.evaluator_model import EvalOutput
 from aiq.eval.evaluator.evaluator_model import EvalOutputItem
+from aiq.eval.utils.tqdm_position_registry import TqdmPositionRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +43,6 @@ class TrajectoryEvaluator:
         self.tools = tools
         self.max_concurrency = max_concurrency
         self.semaphore = asyncio.Semaphore(self.max_concurrency)
-
         # Initialize trajectory evaluation chain
         self.traj_eval_chain = TrajectoryEvalChain.from_llm(llm=self.llm,
                                                             tools=self.tools,
@@ -62,8 +63,12 @@ class TrajectoryEvaluator:
         intermediate_step_adapter = IntermediateStepAdapter()
         event_filter = [IntermediateStepType.LLM_END, IntermediateStepType.TOOL_END]
 
-        async def process_item(item):
-            """Evaluate a single EvalInputItem asynchronously."""
+        async def process_item(item: EvalInputItem) -> tuple[float, dict]:
+            """
+            Evaluate a single EvalInputItem asynchronously and return a tuple of-
+            1. score
+            2. reasoning for the score
+            """
             async with self.semaphore:
                 question = item.input_obj
                 generated_answer = item.output_obj
@@ -87,8 +92,19 @@ class TrajectoryEvaluator:
                 }
                 return eval_result["score"], reasoning
 
+        async def wrapped_process(item: EvalInputItem) -> None:
+            result = await process_item(item)
+            pbar.update(1)
+            return result
+
         # Execute all evaluations asynchronously
-        results = await tqdm.gather(*[process_item(item) for item in eval_input.eval_input_items])
+        try:
+            tqdm_position = TqdmPositionRegistry.claim()
+            pbar = tqdm(total=len(eval_input.eval_input_items), desc="Evaluating Trajectory", position=tqdm_position)
+            results = await asyncio.gather(*[wrapped_process(item) for item in eval_input.eval_input_items])
+        finally:
+            pbar.close()
+            TqdmPositionRegistry.release(tqdm_position)
 
         # Extract scores and reasonings
         sample_scores, sample_reasonings = zip(*results) if results else ([], [])

--- a/src/aiq/eval/utils/tqdm_position_registry.py
+++ b/src/aiq/eval/utils/tqdm_position_registry.py
@@ -19,13 +19,14 @@ class TqdmPositionRegistry:
     A simple registry for tqdm positions.
     """
     _positions = set()
+    _max_positions = 100
 
     @classmethod
     def claim(cls) -> int:
         """
         Claim a tqdm position in the range of 0-99.
         """
-        for i in range(100):
+        for i in range(cls._max_positions):
             if i not in cls._positions:
                 cls._positions.add(i)
                 return i

--- a/src/aiq/eval/utils/tqdm_position_registry.py
+++ b/src/aiq/eval/utils/tqdm_position_registry.py
@@ -1,0 +1,14 @@
+class TqdmPositionRegistry:
+    _positions = set()
+
+    @classmethod
+    def claim(cls) -> int:
+        for i in range(100):
+            if i not in cls._positions:
+                cls._positions.add(i)
+                return i
+        raise RuntimeError("No available tqdm positions.")
+
+    @classmethod
+    def release(cls, pos: int):
+        cls._positions.discard(pos)

--- a/src/aiq/eval/utils/tqdm_position_registry.py
+++ b/src/aiq/eval/utils/tqdm_position_registry.py
@@ -1,8 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 class TqdmPositionRegistry:
+    """
+    A simple registry for tqdm positions.
+    """
     _positions = set()
 
     @classmethod
     def claim(cls) -> int:
+        """
+        Claim a tqdm position in the range of 0-99.
+        """
         for i in range(100):
             if i not in cls._positions:
                 cls._positions.add(i)
@@ -11,4 +33,7 @@ class TqdmPositionRegistry:
 
     @classmethod
     def release(cls, pos: int):
+        """
+        Release a tqdm position.
+        """
         cls._positions.discard(pos)


### PR DESCRIPTION
This PR aims to improve the clarity of progress reporting when evaluators run in parallel by introducing a simple tqdm position registry and integrating it across multiple evaluator modules.

Added TqdmPositionRegistry to manage progress bar positions.
Updated trajectory and RAG evaluators to use the registry for clearer progress display.
Wrapped workflow execution with progress bar updates for overall evaluation tasks.
```
Evaluating Ragas nv_context_relevance: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:11<00:00,  1.85s/it]
Evaluating Ragas nv_response_groundedness: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:12<00:00,  2.10s/it]
Evaluating Ragas nv_accuracy: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:13<00:00,  2.19s/it]
Evaluating Trajectory: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:12<00:00,  2.05s/it]
```