### PR TITLE
Scripts for running CI locally

### DIFF
--- a/ci/scripts/bootstrap_local_ci.sh
+++ b/ci/scripts/bootstrap_local_ci.sh
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export WORKSPACE_TMP="${LOCAL_CI_TMP}/local_ci_workspace"
-mkdir -p ${WORKSPACE_TMP}
-
 if [[ "${USE_HOST_GIT}" == "1" ]]; then
     cd agentiq/
     git config --global --add safe.directory /agentiq
@@ -37,6 +34,11 @@ fi
 
 export WORKSPACE=$(pwd)
 export LOCAL_CI=1
+export WORKSPACE_TMP="${LOCAL_CI_TMP}/local_ci_workspace"
+export UV_CACHE_DIR="${WORKSPACE_TMP}/uv_cache"
+export PRE_COMMIT_HOME="${WORKSPACE_TMP}/pre_commit"
+mkdir -p ${UV_CACHE_DIR}
+
 GH_SCRIPT_DIR="${WORKSPACE}/ci/scripts/github"
 
 

--- a/ci/scripts/bootstrap_local_ci.sh
+++ b/ci/scripts/bootstrap_local_ci.sh
@@ -38,8 +38,8 @@ fi
 export WORKSPACE=$(pwd)
 export LOCAL_CI=1
 export WORKSPACE_TMP="${LOCAL_CI_TMP}/local_ci_workspace"
-export UV_CACHE_DIR="${WORKSPACE_TMP}/uv_cache"
-export PRE_COMMIT_HOME="${WORKSPACE_TMP}/pre_commit"
+export UV_CACHE_DIR="${LOCAL_CI_TMP}/cache/uv"
+export PRE_COMMIT_HOME="${LOCAL_CI_TMP}/cache/pre_commit"
 mkdir -p ${UV_CACHE_DIR}
 
 GH_SCRIPT_DIR="${WORKSPACE}/ci/scripts/github"

--- a/ci/scripts/bootstrap_local_ci.sh
+++ b/ci/scripts/bootstrap_local_ci.sh
@@ -17,6 +17,9 @@
 if [[ "${USE_HOST_GIT}" == "1" ]]; then
     cd agentiq/
     git config --global --add safe.directory /agentiq
+
+    # Avoids SSH host key verification prompt
+    ssh-keyscan github.com >> /etc/ssh/ssh_known_hosts
 else
     git clone ${GIT_URL} agentiq
     cd agentiq/

--- a/ci/scripts/bootstrap_local_ci.sh
+++ b/ci/scripts/bootstrap_local_ci.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export WORKSPACE_TMP="$(pwd)/.tmp/local_ci_workspace"
+mkdir -p ${WORKSPACE_TMP}
+
+if [[ "${USE_HOST_GIT}" == "1" ]]; then
+    cd agentiq/
+    git config --global --add safe.directory /agentiq
+else
+    git clone ${GIT_URL} agentiq
+    cd agentiq/
+    git remote add upstream ${GIT_UPSTREAM_URL}
+    git fetch upstream
+    git checkout develop
+    git checkout ${GIT_BRANCH}
+    git pull
+    git checkout ${GIT_COMMIT}
+    git fetch --all --tags
+
+    export CURRENT_BRANCH=${GIT_BRANCH}
+    export COMMIT_SHA=${GIT_COMMIT}
+fi
+
+export WORKSPACE=$(pwd)
+export LOCAL_CI=1
+GH_SCRIPT_DIR="${WORKSPACE}/ci/scripts/github"
+
+
+if [[ "${STAGE}" != "bash" ]]; then
+
+    CI_SCRIPT="${GH_SCRIPT_DIR}/${STAGE}.sh"
+
+    ${CI_SCRIPT}
+fi

--- a/ci/scripts/bootstrap_local_ci.sh
+++ b/ci/scripts/bootstrap_local_ci.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export WORKSPACE_TMP="$(pwd)/.tmp/local_ci_workspace"
+export WORKSPACE_TMP="${LOCAL_CI_TMP}/local_ci_workspace"
 mkdir -p ${WORKSPACE_TMP}
 
 if [[ "${USE_HOST_GIT}" == "1" ]]; then

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -26,12 +26,12 @@ export PY_DIRS="${PY_ROOT} ${PROJECT_ROOT}/packages ${PROJECT_ROOT}/tests ${PROJ
 export AIQ_LOG_LEVEL=WARN
 export CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-"develop"}
 
-if [[ "${GITHUB_ACTIONS}" == "true" ]]; then
-   export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target)}
-   export COMMIT_SHA=${COMMIT_SHA:-${GITHUB_SHA}}
-else
+if [[ "${GITLAB_CI}" == "true" ]]; then
    export BASE_SHA=${BASE_SHA:-${CI_MERGE_REQUEST_TARGET_BRANCH_SHA:-${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target --current-branch=${CURRENT_BRANCH})}}}
    export COMMIT_SHA=${CI_COMMIT_SHA:-${COMMIT_SHA:-HEAD}}
+else
+   export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target)}
+   export COMMIT_SHA=${COMMIT_SHA:-${GITHUB_SHA:-HEAD}}
 fi
 
 
@@ -39,9 +39,6 @@ export PYTHON_FILE_REGEX='^(\.\/)?(?!\.|build|external).*\.(py|pyx|pxd)$'
 
 # Use these options to skip any of the checks
 export SKIP_COPYRIGHT=${SKIP_COPYRIGHT:-""}
-
-# Set BUILD_DIR to use a different build folder
-export BUILD_DIR=${BUILD_DIR:-"${PROJECT_ROOT}/build"}
 
 
 # Determine the merge base as the root to compare against. Optionally pass in a

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -30,11 +30,8 @@ if [[ "${GITLAB_CI}" == "true" ]]; then
    export BASE_SHA=${BASE_SHA:-${CI_MERGE_REQUEST_TARGET_BRANCH_SHA:-${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target --current-branch=${CURRENT_BRANCH})}}}
    export COMMIT_SHA=${CI_COMMIT_SHA:-${COMMIT_SHA:-HEAD}}
 else
-   echo "------------- 0 -------------"
    export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target)}
-   echo "------------- 1 -------------"
    export COMMIT_SHA=${COMMIT_SHA:-${GITHUB_SHA:-HEAD}}
-   echo "------------- 2 -------------"
 fi
 
 

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -30,8 +30,11 @@ if [[ "${GITLAB_CI}" == "true" ]]; then
    export BASE_SHA=${BASE_SHA:-${CI_MERGE_REQUEST_TARGET_BRANCH_SHA:-${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target --current-branch=${CURRENT_BRANCH})}}}
    export COMMIT_SHA=${CI_COMMIT_SHA:-${COMMIT_SHA:-HEAD}}
 else
+   echo "------------- 0 -------------"
    export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target)}
+   echo "------------- 1 -------------"
    export COMMIT_SHA=${COMMIT_SHA:-${GITHUB_SHA:-HEAD}}
+   echo "------------- 2 -------------"
 fi
 
 

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -32,8 +32,10 @@ if [[ "${GITLAB_CI}" == "true" ]]; then
 else
    echo "------------- 0 -------------"
    if [[ "${CURRENT_BRANCH}" != "" ]]; then
+      echo "------------- 0.1 -------------"
       export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target --current-branch=${CURRENT_BRANCH})}
    else
+      echo "------------- 0.2 -------------"
       export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target)}
    fi
    echo "------------- 1 -------------"

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -31,7 +31,7 @@ if [[ "${GITLAB_CI}" == "true" ]]; then
    export COMMIT_SHA=${CI_COMMIT_SHA:-${COMMIT_SHA:-HEAD}}
 else
    echo "------------- 0 -------------"
-   if [[ "${CURRENT_BRANCH}" != ""]]; then
+   if [[ "${CURRENT_BRANCH}" != "" ]]; then
       export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target --current-branch=${CURRENT_BRANCH})}
    else
       export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target)}

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -31,7 +31,11 @@ if [[ "${GITLAB_CI}" == "true" ]]; then
    export COMMIT_SHA=${CI_COMMIT_SHA:-${COMMIT_SHA:-HEAD}}
 else
    echo "------------- 0 -------------"
-   export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target)}
+   if [[ "${CURRENT_BRANCH}" != ""]]; then
+      export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target --current-branch=${CURRENT_BRANCH})}
+   else
+      export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target)}
+   fi
    echo "------------- 1 -------------"
    export COMMIT_SHA=${COMMIT_SHA:-${GITHUB_SHA:-HEAD}}
    echo "------------- 2 -------------"

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -31,13 +31,7 @@ if [[ "${GITLAB_CI}" == "true" ]]; then
    export COMMIT_SHA=${CI_COMMIT_SHA:-${COMMIT_SHA:-HEAD}}
 else
    echo "------------- 0 -------------"
-   if [[ "${CURRENT_BRANCH}" != "" ]]; then
-      echo "------------- 0.1 -------------"
-      export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target --current-branch=${CURRENT_BRANCH})}
-   else
-      echo "------------- 0.2 -------------"
-      export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target)}
-   fi
+   export BASE_SHA=${BASE_SHA:-$(${SCRIPT_DIR}/gitutils.py get_merge_target)}
    echo "------------- 1 -------------"
    export COMMIT_SHA=${COMMIT_SHA:-${GITHUB_SHA:-HEAD}}
    echo "------------- 2 -------------"

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -48,7 +48,7 @@ function create_env() {
     done
 
     rapids-logger "Creating uv env"
-    VENV_DIR="${WORKSPACE_TMP}/.ci_venv"
+    VENV_DIR="${WORKSPACE_TMP}/.venv"
     uv venv --seed ${VENV_DIR}
     source ${VENV_DIR}/bin/activate
 

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -48,7 +48,7 @@ function create_env() {
     done
 
     rapids-logger "Creating uv env"
-    VENV_DIR=".ci_venv"
+    VENV_DIR="${WORKSPACE_TMP}/.ci_venv"
     uv venv --seed ${VENV_DIR}
     source ${VENV_DIR}/bin/activate
 

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -48,7 +48,7 @@ function create_env() {
     done
 
     rapids-logger "Creating uv env"
-    VENV_DIR="${WORKSPACE_TMP}/.venv"
+    VENV_DIR=".venv"
     uv venv --seed ${VENV_DIR}
     source ${VENV_DIR}/bin/activate
 

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -73,10 +73,14 @@ function get_lfs_files() {
     apt update
     apt install --no-install-recommends -y git-lfs
 
-    rapids-logger "Fetching LFS files"
-    git lfs install
-    git lfs fetch
-    git lfs pull
+    if [[ "${USE_HOST_GIT}" == "1" ]]; then
+        rapids-logger "Using host git, skipping git-lfs install"
+    else
+        rapids-logger "Fetching LFS files"
+        git lfs install
+        git lfs fetch
+        git lfs pull
+    fi
 
     rapids-logger "git lfs ls-files"
     git lfs ls-files

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -54,7 +54,7 @@ function create_env() {
 
     rapids-logger "Creating Environment with extras: ${@}"
 
-    UV_SYNC_STDERROUT=$(uv sync ${extras[@]} 2>&1)
+    UV_SYNC_STDERROUT=$(uv sync --active ${extras[@]} 2>&1)
 
     # Environment should have already been created in the before_script
     if [[ "${UV_SYNC_STDERROUT}" =~ "warning:" ]]; then

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -47,9 +47,10 @@ function create_env() {
         fi
     done
 
-    rapids-logger "Installing uv"
-    uv venv --seed .venv
-    source .venv/bin/activate
+    rapids-logger "Creating uv env"
+    VENV_DIR="${WORKSPACE_TMP}/.venv"
+    uv venv --seed ${VENV_DIR}
+    source ${VENV_DIR}/bin/activate
 
     rapids-logger "Creating Environment with extras: ${@}"
 

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -48,7 +48,7 @@ function create_env() {
     done
 
     rapids-logger "Creating uv env"
-    VENV_DIR=".venv"
+    VENV_DIR=".ci_venv"
     uv venv --seed ${VENV_DIR}
     source ${VENV_DIR}/bin/activate
 

--- a/ci/scripts/github/docs.sh
+++ b/ci/scripts/github/docs.sh
@@ -33,3 +33,5 @@ DOCS_TAR=${WORKSPACE_TMP}/docs.tar.bz2
 rapids-logger "Archiving documentation to ${DOCS_TAR}"
 tar cvfj ${DOCS_TAR} build/html
 popd
+
+rapids-logger "Documentation build completed"

--- a/ci/scripts/gitutils.py
+++ b/ci/scripts/gitutils.py
@@ -117,8 +117,7 @@ class GitWrapper:
     def get_repo_owner_name():
 
         # pylint: disable=anomalous-backslash-in-string
-        return "chat-labs/OpenSource/" + _run_cmd(
-            "git remote -v | grep -oP '/\K\w*(?=\.git \(fetch\))' | head -1")  # noqa: W605
+        return "NVIDIA/" + _run_cmd("git remote -v | grep -oP '/\\K\\w*(?=\\.git \\(fetch\\))' | head -1")
 
     @functools.lru_cache
     @staticmethod

--- a/ci/scripts/run_ci_local.sh
+++ b/ci/scripts/run_ci_local.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+case "$1" in
+    "" )
+        STAGES=("bash")
+        ;;
+    "all" )
+        STAGES=("checks" "tests" "docs" "build_wheel")
+        ;;
+    "checks" | "tests" | "docs" | "build_wheel" | "bash" )
+        STAGES=("$1")
+        ;;
+    * )
+        echo "Error: Invalid argument \"$1\" provided. Expected values: \"all\", \"checks\", \"tests\", " \
+             "\"docs\", \"build_wheel\" or \"bash\""
+        exit 1
+        ;;
+esac
+
+# Use the HTTPS URL to avoid needing to expose SSH_AUTH_SOCK to the container
+function git_ssh_to_https()
+{
+    local url=$1
+    echo $url | sed -e 's|^git@github\.com:|https://github.com/|'
+}
+
+CI_ARCH=${CI_ARCH:-$(dpkg --print-architecture)}
+AGENTIQ_ROOT=${AGENTIQ_ROOT:-$(git rev-parse --show-toplevel)}
+
+GIT_URL=$(git remote get-url origin)
+GIT_URL=$(git_ssh_to_https ${GIT_URL})
+
+GIT_UPSTREAM_URL=$(git remote get-url upstream)
+GIT_UPSTREAM_URL=$(git_ssh_to_https ${GIT_UPSTREAM_URL})
+
+GIT_BRANCH=$(git branch --show-current)
+GIT_COMMIT=$(git log -n 1 --pretty=format:%H)
+
+# Specifies whether to mount the current git repo or to use a clean clone (the default)
+USE_HOST_GIT=${USE_HOST_GIT:-0}
+
+LOCAL_CI_TMP=${LOCAL_CI_TMP:-${AGENTIQ_ROOT}/.tmp/local_ci_tmp}
+DOCKER_EXTRA_ARGS=${DOCKER_EXTRA_ARGS:-""}
+
+CI_CONTAINER=${CI_CONTAINER:-"ghcr.io/astral-sh/uv:python3.12-bookworm"}
+
+
+# These variables are common to all stages
+BASE_ENV_LIST="--env LOCAL_CI_TMP=/ci_tmp"
+BASE_ENV_LIST="${BASE_ENV_LIST} --env GIT_URL=${GIT_URL}"
+BASE_ENV_LIST="${BASE_ENV_LIST} --env GIT_UPSTREAM_URL=${GIT_UPSTREAM_URL}"
+BASE_ENV_LIST="${BASE_ENV_LIST} --env GIT_BRANCH=${GIT_BRANCH}"
+BASE_ENV_LIST="${BASE_ENV_LIST} --env GIT_COMMIT=${GIT_COMMIT}"
+BASE_ENV_LIST="${BASE_ENV_LIST} --env USE_HOST_GIT=${USE_HOST_GIT}"
+
+for STAGE in "${STAGES[@]}"; do
+    # Take a copy of the base env list, then make stage specific changes
+    ENV_LIST="${BASE_ENV_LIST}"
+
+    mkdir -p ${LOCAL_CI_TMP}
+    cp ${AGENTIQ_ROOT}/ci/scripts/bootstrap_local_ci.sh ${LOCAL_CI_TMP}
+
+    DOCKER_RUN_ARGS="--rm -ti --net=host --platform=linux/${CI_ARCH} -v "${LOCAL_CI_TMP}":/ci_tmp ${ENV_LIST} --env STAGE=${STAGE}"
+
+    if [[ "${USE_HOST_GIT}" == "1" ]]; then
+        DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} -v ${AGENTIQ_ROOT}:/agentiq"
+    fi
+
+    if [[ "${STAGE}" == "bash" ]]; then
+        DOCKER_RUN_CMD="bash --init-file /ci_tmp/bootstrap_local_ci.sh"
+    else
+        DOCKER_RUN_CMD="/ci_tmp/bootstrap_local_ci.sh"
+    fi
+
+    echo "Running ${STAGE} stage in ${CI_CONTAINER}"
+    docker run ${DOCKER_RUN_ARGS} ${DOCKER_EXTRA_ARGS} ${CI_CONTAINER} ${DOCKER_RUN_CMD}
+
+    STATUS=$?
+    if [[ ${STATUS} -ne 0 ]]; then
+        echo "Error: docker exited with a non-zero status code for ${STAGE} of ${STATUS}"
+        exit ${STATUS}
+    fi
+done

--- a/ci/scripts/run_ci_local.sh
+++ b/ci/scripts/run_ci_local.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/source/advanced/contributing.md
+++ b/docs/source/advanced/contributing.md
@@ -131,6 +131,7 @@ AgentIQ is a Python library that doesn’t require a GPU to run the workflow by 
 1. Code!
     - Make sure to update unit tests!
     - Ensure the [license headers are set properly](#licensing).
+1. Verify your changes by [running CI locally](./running-ci-locally.md) with the `./ci/scripts/run_ci_local.sh all` command.
 1. When done, [create your pull request](https://github.com/NVIDIA/AgentIQ/compare). Select `develop` as the `Target branch` of your pull request.
     - Ensure the body of the pull request references the issue you are working on in the form of `Closes #<issue number>`.
 1. Wait for other developers to review your code and update code as needed.

--- a/docs/source/advanced/index.md
+++ b/docs/source/advanced/index.md
@@ -21,4 +21,5 @@ limitations under the License.
 :maxdepth: 20
 
 Contributing <./contributing.md>
+Running CI Locally <./running-ci-locally.md>
 ```

--- a/docs/source/advanced/running-ci-locally.md
+++ b/docs/source/advanced/running-ci-locally.md
@@ -1,0 +1,48 @@
+# Running CI Locally
+
+The `ci/scripts/run_ci_local.sh` attempts to mirror the behavior of the Github Actions CI pipeline, by running the same CI scripts within the same Docker container that is used in the CI pipeline with the same environment variables needed.
+
+By default the script will perform a `git clone` and checkout the latest commit. This requires the latest commit to be pushed. Alternately setting the environment variable `USE_HOST_GIT=1` the host's repo will be mounted inside the CI container, avoiding the need to commit/push changes. This option requires all Git LFS files to be checked out first.
+
+> Note: We don't set all of the same environment variables that Github Actions would set, just the ones needed by our own CI scripts.
+
+
+## Prerequisites
+- [Docker](https://docs.docker.com/get-docker/)
+- AgentIQ source repository cloned locally with both the `origin` and `upstream` remotes set up. Refer to [Creating the Environment](./contributing.md#creating-the-environment) for more details.
+
+## Usage
+Typical usage is as follows:
+```bash
+./ci/scripts/run_ci_local.sh <CI stage>
+```
+
+For example, to run the `checks` stage:
+```bash
+./ci/scripts/run_ci_local.sh checks
+```
+
+To run all CI stages, you can use:
+```bash
+./ci/scripts/run_ci_local.sh all
+```
+
+## Debugging CI
+
+To debug a CI issue, you can use the `bash` pseudo-stage. This will perform a git clone & checkout, and then drop you in a bash shell with all of the CI variables set.
+```bash
+./ci/scripts/run_ci_local.sh bash
+```
+
+From this point you can manually copy/paste the commands which would normally be run by the CI scripts one command at a time. The Github Actions CI scripts for AgentIQ are located in the `ci/scripts/github` directory, these scripts are Github Actions specific wrappers for scripts located in the `ci/scripts` directory.
+
+## CI Artifacts and Cache
+
+| Name | Description | Location |
+|--|--|--|
+| Artifacts | Test results, wheels, and documentation | `.tmp/local_ci_tmp/local_ci_workspace` |
+| Cache | `uv` and `pre-commit` package caches | `.tmp/local_ci_tmp/cache` |
+| Virtual Environment | Python virtual environment | `.tmp/local_ci_tmp/local_ci_workspace/.venv` |
+| Bootstrap Script | The script used to bootstrap the CI environment within the CI container | `.tmp/local_ci_tmp/bootstrap_local_ci.sh` |
+
+> Note: In some situations it may be necessary to delete the `.tmp/local_ci_tmp` directory to clear out old artifacts and caches. This is especially true if you are switching between branches or if you are running into issues with the CI pipeline.

--- a/docs/source/advanced/running-ci-locally.md
+++ b/docs/source/advanced/running-ci-locally.md
@@ -1,3 +1,20 @@
+<!--
+    SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    SPDX-License-Identifier: Apache-2.0
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
 # Running CI Locally
 
 The `ci/scripts/run_ci_local.sh` attempts to mirror the behavior of the Github Actions CI pipeline, by running the same CI scripts within the same Docker container that is used in the CI pipeline with the same environment variables needed.

--- a/docs/source/advanced/running-ci-locally.md
+++ b/docs/source/advanced/running-ci-locally.md
@@ -17,11 +17,11 @@
 
 # Running CI Locally
 
-The `ci/scripts/run_ci_local.sh` attempts to mirror the behavior of the Github Actions CI pipeline, by running the same CI scripts within the same Docker container that is used in the CI pipeline with the same environment variables needed.
+The `ci/scripts/run_ci_local.sh` attempts to mirror the behavior of the GitHub Actions CI pipeline, by running the same CI scripts within the same Docker container that is used in the CI pipeline with the same environment variables needed.
 
 By default the script will perform a `git clone` and checkout the latest commit. This requires the latest commit to be pushed. Alternately setting the environment variable `USE_HOST_GIT=1` the host's repo will be mounted inside the CI container, avoiding the need to commit/push changes. This option requires all Git LFS files to be checked out first.
 
-> Note: We don't set all of the same environment variables that Github Actions would set, just the ones needed by our own CI scripts.
+> Note: We don't set all of the same environment variables that GitHub Actions would set, just the ones needed by our own CI scripts.
 
 
 ## Prerequisites
@@ -51,7 +51,7 @@ To debug a CI issue, you can use the `bash` pseudo-stage. This will perform a gi
 ./ci/scripts/run_ci_local.sh bash
 ```
 
-From this point you can manually copy/paste the commands which would normally be run by the CI scripts one command at a time. The Github Actions CI scripts for AgentIQ are located in the `ci/scripts/github` directory, these scripts are Github Actions specific wrappers for scripts located in the `ci/scripts` directory.
+From this point you can manually copy/paste the commands which would normally be run by the CI scripts one command at a time. The GitHub Actions CI scripts for AgentIQ are located in the `ci/scripts/github` directory, these scripts are GitHub Actions specific wrappers for scripts located in the `ci/scripts` directory.
 
 ## CI Artifacts and Cache
 


### PR DESCRIPTION
## Description
* Adds a `ci/scripts/run_ci_local.sh` script allowing for executing CI scripts locally mirroring the GHA CI pipeline as closely as possible.
* uv and pre-commit packages are cached in `.tmp/local_ci_tmp/cache`
* uv's venv is located in `.tmp/local_ci_tmp/local_ci_workspace/.venv`
* By default the script will perform a `git clone` and checkout the latest commit. This requires the latest commit to be pushed.
* Alternately setting the environment variable `USE_HOST_GIT=1` the host's repo will be mounted inside the CI container, avoiding the need to commit/push changes. (Note: Doing so requires all git-lfs files to be checked out first).
* Fix escape sequences in `ci/scripts/gitutils.py`

Usage:
* Run the entire CI pipeline:
```bash
./ci/scripts/run_ci_local.sh all
```

* Run just the checks stage:
```bash
./ci/scripts/run_ci_local.sh checks
```

* Debug a CI issue with the `bash` pseudo-stage. This will perform a git clone & checkout, and then drop you in a bash shell with all of the CI variables set.
```bash
./ci/scripts/run_ci_local.sh bash
```


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
