### PR TITLE
Fix `aiq` command error when the parent directory of `AIQ_CONFIG_DIR` does not exist

### DIFF
--- a/src/aiq/settings/global_settings.py
+++ b/src/aiq/settings/global_settings.py
@@ -155,7 +155,7 @@ class Settings(HashableBaseModel):
         configuration_directory = os.getenv("AIQ_CONFIG_DIR", user_config_dir(appname="aiq"))
 
         if not os.path.exists(configuration_directory):
-            os.mkdir(configuration_directory)
+            os.makedirs(configuration_directory, exist_ok=True)
 
         configuration_file = os.path.join(configuration_directory, "config.json")
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
This issue occurs when the parent directory of `AIQ_CONFIG_DIR` does not exist. Should use `os.makedirs` with `exist_ok=True` to create parent directories when necessary.

Closes #40 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
