### PR TITLE
Normalize Gannt Chart Timestamps in Profiler Nested Stack Analysis 

### DIFF
--- a/src/aiq/profiler/inference_optimization/bottleneck_analysis/nested_stack_analysis.py
+++ b/src/aiq/profiler/inference_optimization/bottleneck_analysis/nested_stack_analysis.py
@@ -329,7 +329,6 @@ def save_gantt_chart(all_nodes: list[CallNode], output_path: str) -> None:
     ax.set_xlim(0, max_end - min_start)
     ax.set_xlabel("Time")
     ax.set_title("Gantt Chart of Nested Calls (All Examples)")
-
     plt.tight_layout()
     plt.savefig(output_path, dpi=150)
     plt.close(fig)

--- a/src/aiq/profiler/inference_optimization/bottleneck_analysis/nested_stack_analysis.py
+++ b/src/aiq/profiler/inference_optimization/bottleneck_analysis/nested_stack_analysis.py
@@ -303,6 +303,8 @@ def save_gantt_chart(all_nodes: list[CallNode], output_path: str) -> None:
 
     # Sort calls by start_time
     sorted_nodes = sorted(all_nodes, key=lambda x: x.start_time)
+    min_start = min(node.start_time for node in sorted_nodes)
+    max_end = max(node.end_time for node in sorted_nodes)
 
     color_map = {
         "LLM": "tab:blue",
@@ -318,12 +320,13 @@ def save_gantt_chart(all_nodes: list[CallNode], output_path: str) -> None:
         start = node.start_time
         width = node.end_time - node.start_time
         c = color_map.get(node.operation_type, default_color)
-        ax.barh(y=i, width=width, left=start, height=0.6, color=c, edgecolor="black")
+        ax.barh(y=i, width=width, left=start - min_start, height=0.6, color=c, edgecolor="black")
         labels.append(f"{node.operation_type}:{node.operation_name}")
 
     ax.set_yticks(list(y_positions))
     ax.set_yticklabels(labels)
     ax.invert_yaxis()
+    ax.set_xlim(0, max_end - min_start)
     ax.set_xlabel("Time")
     ax.set_title("Gantt Chart of Nested Calls (All Examples)")
 


### PR DESCRIPTION
## Description
Improves readability of the Nested Stack Analysis Gantt chart by using relative timestamps instead of epoch timestamps. 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
