### PR TITLE
Update types for `topic` and `description` attributes in  `AIQRetrieverConfig` to allow `None`

### DIFF
--- a/src/aiq/tool/retriever.py
+++ b/src/aiq/tool/retriever.py
@@ -40,8 +40,8 @@ class AIQRetrieverConfig(FunctionBaseConfig, name="aiq_retriever"):
         default=True,
         description="If true the tool will raise exceptions, otherwise it will log them as warnings and return []",
     )
-    topic: str = Field(default=None, description="Used to provide a more detailed tool description to the agent")
-    description: str = Field(default=None, description="If present it will be used as the tool description")
+    topic: str = Field(default="", description="Used to provide a more detailed tool description to the agent")
+    description: str = Field(default="", description="If present it will be used as the tool description")
 
 
 def _get_description_from_config(config: AIQRetrieverConfig) -> str:

--- a/src/aiq/tool/retriever.py
+++ b/src/aiq/tool/retriever.py
@@ -40,8 +40,8 @@ class AIQRetrieverConfig(FunctionBaseConfig, name="aiq_retriever"):
         default=True,
         description="If true the tool will raise exceptions, otherwise it will log them as warnings and return []",
     )
-    topic: str = Field(default="", description="Used to provide a more detailed tool description to the agent")
-    description: str = Field(default="", description="If present it will be used as the tool description")
+    topic: str | None = Field(default=None, description="Used to provide a more detailed tool description to the agent")
+    description: str | None = Field(default=None, description="If present it will be used as the tool description")
 
 
 def _get_description_from_config(config: AIQRetrieverConfig) -> str:

--- a/tests/aiq/tools/test_retriever.py
+++ b/tests/aiq/tools/test_retriever.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import typing
+
+import pytest
+
+from aiq.tool.retriever import AIQRetrieverConfig
+
+
+@pytest.mark.parametrize(
+    "config_values",
+    [
+        {
+            "retriever": "test_retriever",
+            "raise_errors": False,
+            "topic": "test_topic",
+            "description": "test_description"
+        },
+        {
+            "retriever": "test_retriever",
+        },
+    ],
+    ids=[
+        "all_fields_provided",
+        "only_required_fields",
+    ]
+)
+def test_retriever_config(config_values: dict[str, typing.Any]):
+    """
+    Test the AIQRetrieverConfig class.
+    """
+
+    AIQRetrieverConfig.model_validate(config_values, strict=True)
+    config = AIQRetrieverConfig(**config_values)
+
+    model_dump = config.model_dump()
+    model_dump.pop('type')
+
+    AIQRetrieverConfig.model_validate(model_dump, strict=True)

--- a/tests/aiq/tools/test_retriever.py
+++ b/tests/aiq/tools/test_retriever.py
@@ -20,24 +20,22 @@ import pytest
 from aiq.tool.retriever import AIQRetrieverConfig
 
 
-@pytest.mark.parametrize(
-    "config_values",
-    [
-        {
-            "retriever": "test_retriever",
-            "raise_errors": False,
-            "topic": "test_topic",
-            "description": "test_description"
-        },
-        {
-            "retriever": "test_retriever",
-        },
-    ],
-    ids=[
-        "all_fields_provided",
-        "only_required_fields",
-    ]
-)
+@pytest.mark.parametrize("config_values",
+                         [
+                             {
+                                 "retriever": "test_retriever",
+                                 "raise_errors": False,
+                                 "topic": "test_topic",
+                                 "description": "test_description"
+                             },
+                             {
+                                 "retriever": "test_retriever",
+                             },
+                         ],
+                         ids=[
+                             "all_fields_provided",
+                             "only_required_fields",
+                         ])
 def test_retriever_config(config_values: dict[str, typing.Any]):
     """
     Test the AIQRetrieverConfig class.


### PR DESCRIPTION
## Description
* Fixes an issue where the `str` type caused validation errors with the default `None` values.

Closes #58

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
