### PR TITLE
Fix bug where `--workers` flag was being ignored

### DIFF
--- a/src/aiq/front_ends/fastapi/fastapi_front_end_plugin.py
+++ b/src/aiq/front_ends/fastapi/fastapi_front_end_plugin.py
@@ -66,6 +66,7 @@ class FastApiFrontEndPlugin(FrontEndBase[FastApiFrontEndConfig]):
                 uvicorn.run("aiq.front_ends.fastapi.main:get_app",
                             host=self.front_end_config.host,
                             port=self.front_end_config.port,
+                            workers=self.front_end_config.workers,
                             reload=self.front_end_config.reload,
                             factory=True,
                             reload_excludes=reload_excludes)
@@ -95,7 +96,7 @@ class FastApiFrontEndPlugin(FrontEndBase[FastApiFrontEndConfig]):
 
                 options = {
                     "bind": f"{self.front_end_config.host}:{self.front_end_config.port}",
-                    "workers": 1,
+                    "workers": self.front_end_config.workers,
                     "worker_class": "uvicorn.workers.UvicornWorker",
                 }
 


### PR DESCRIPTION
## Description
* `aiq serve` was ignoring the `--workers` flag.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
