### PR TITLE
Fix a bug in our pytest plugin causing test coverage to be under-reported

### DIFF
--- a/packages/agentiq_test/src/aiq/test/plugin.py
+++ b/packages/agentiq_test/src/aiq/test/plugin.py
@@ -15,9 +15,6 @@
 
 import pytest
 
-from aiq.runtime.loader import PluginTypes
-from aiq.runtime.loader import discover_and_register_plugins
-
 
 def pytest_addoption(parser: pytest.Parser):
     """
@@ -62,6 +59,8 @@ def pytest_runtest_setup(item):
 
 @pytest.fixture(name="register_components", scope="session", autouse=True)
 def register_components_fixture():
+    from aiq.runtime.loader import PluginTypes
+    from aiq.runtime.loader import discover_and_register_plugins
 
     # Ensure that all components which need to be registered as part of an import are done so. This is necessary
     # because imports will not be reloaded between tests, so we need to ensure that all components are registered
@@ -83,7 +82,6 @@ def module_registry_fixture():
 
     with GlobalTypeRegistry.push() as registry:
         yield registry
-
 
 @pytest.fixture(name="registry", scope="function", autouse=True)
 def function_registry_fixture():

--- a/packages/agentiq_test/src/aiq/test/plugin.py
+++ b/packages/agentiq_test/src/aiq/test/plugin.py
@@ -83,6 +83,7 @@ def module_registry_fixture():
     with GlobalTypeRegistry.push() as registry:
         yield registry
 
+
 @pytest.fixture(name="registry", scope="function", autouse=True)
 def function_registry_fixture():
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ dev = [
   "pylint==3.3.*",
   "pytest_httpserver==1.1.*",
   "pytest-asyncio==0.24.*",
-  "pytest-cov~=6.0",
+  "pytest-cov~=6.1",
   "pytest~=8.3",
   "python-docx~=1.1.0",
   "setuptools >= 64",

--- a/src/aiq/tool/github_tools/get_github_issue.py
+++ b/src/aiq/tool/github_tools/get_github_issue.py
@@ -18,7 +18,7 @@ from typing import Literal
 
 from pydantic import BaseModel
 from pydantic import Field
-from pydantic import validator
+from pydantic import field_validator
 
 from aiq.builder.builder import Builder
 from aiq.builder.function_info import FunctionInfo
@@ -35,7 +35,7 @@ class GithubListIssueModel(BaseModel):
     since: str | None = Field(None, description="Only show results that were last updated after the given time.")
 
     @classmethod
-    @validator('since', pre=True, always=True)
+    @field_validator('since', mode='before')
     def validate_since(cls, v):
         if v is None:
             return v

--- a/tests/aiq/front_ends/fastapi/test_fastapi_front_end_config.py
+++ b/tests/aiq/front_ends/fastapi/test_fastapi_front_end_config.py
@@ -116,6 +116,7 @@ def test_cross_origin_resource_sharing(cors_kwargs: dict):
         assert isinstance(model.expose_headers, list)
         assert isinstance(model.max_age, int)
 
+
 @pytest.mark.parametrize(
     "config_kwargs", [FAST_API_FRONT_END_CONFIG_ALL_VALUES.copy(), FAST_API_FRONT_END_CONFIG_REQUIRES_VALUES.copy()],
     ids=["all-values", "required-values"])

--- a/tests/aiq/front_ends/fastapi/test_fastapi_front_end_config.py
+++ b/tests/aiq/front_ends/fastapi/test_fastapi_front_end_config.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import pytest
+from pydantic import BaseModel
 
 from aiq.front_ends.fastapi.fastapi_front_end_config import FastApiFrontEndConfig
 
@@ -27,20 +28,64 @@ ENDPOINT_BASE_ALL_VALUES = {
 
 ENDPOINT_BASE_REQUIRED_VALUES = {"method": "POST", "description": "only required values"}
 
+ENDPOINT_ALL_VALUES = ENDPOINT_BASE_ALL_VALUES | {'function_name': 'apples'}
+
+ENDPOINT_REQUIRED_VALUES = ENDPOINT_BASE_REQUIRED_VALUES | {'function_name': 'oranges'}
+
+CORS_ALL_VALUES = {
+    "allow_origins": ["http://example.com", "https://example.com"],
+    "allow_origin_regex": r"^https?://.*\.example\.com$",
+    "allow_methods": ["GET", "POST"],
+    "allow_headers": ["Content-Type"],
+    "allow_credentials": True,
+    "expose_headers": ["X-Custom-Header"],
+    "max_age": 3600
+}
+
+CORS_REQUIRED_VALUES = {}
+
+FAST_API_FRONT_END_CONFIG_ALL_VALUES = {
+    "root_path": "/endpoint",
+    "host": "testhost",
+    "port": 8080,
+    "reload": True,
+    "workers": 4,
+    "step_adaptor": {
+        "mode": "custom", "custom_event_types": ["CUSTOM_START", "CUSTOM_END"]
+    },
+    "workflow": ENDPOINT_BASE_ALL_VALUES.copy(),
+    "endpoints": [ENDPOINT_ALL_VALUES.copy()],
+    "cors": CORS_ALL_VALUES.copy(),
+    "use_gunicorn": True,
+    "runner_class": "test_runner_class"
+}
+
+FAST_API_FRONT_END_CONFIG_REQUIRES_VALUES = {}
+
+
 def _test_model_instantiation(model_class, model_kwargs):
     """
     Helper function to test instantiation of a Pydantic model.
     """
     model = model_class(**model_kwargs)
     assert model.model_fields_set == model_kwargs.keys()
-    for (key, value) in model_kwargs.items():
-        assert getattr(model, key) == value
+    for (key, expected_value) in model_kwargs.items():
+        actual_value = getattr(model, key)
+        if isinstance(actual_value, BaseModel) and isinstance(expected_value, dict):
+            _test_model_instantiation(actual_value.__class__, expected_value)
+        elif isinstance(actual_value, list) and isinstance(expected_value, list):
+            for (i, v) in enumerate(actual_value):
+                if isinstance(v, BaseModel) and isinstance(expected_value[i], dict):
+                    _test_model_instantiation(v.__class__, expected_value[i])
+                else:
+                    assert v == expected_value[i]
+        else:
+            assert actual_value == expected_value
 
     return model
 
 
-@pytest.mark.parametrize("endpoint_kwargs",
-                         [ENDPOINT_BASE_ALL_VALUES.copy(), ENDPOINT_BASE_REQUIRED_VALUES.copy()],
+@pytest.mark.parametrize("endpoint_kwargs", [ENDPOINT_BASE_ALL_VALUES.copy(), ENDPOINT_BASE_REQUIRED_VALUES.copy()],
                          ids=["all-values", "required-values"])
 def test_endpoint_base(endpoint_kwargs: dict):
     _test_model_instantiation(FastApiFrontEndConfig.EndpointBase, endpoint_kwargs)
@@ -51,29 +96,14 @@ def test_endpoint_base_invalid_method():
         FastApiFrontEndConfig.EndpointBase(method="INVALID", description="test")
 
 
-@pytest.mark.parametrize("endpoint_kwargs",
-                         [
-                             ENDPOINT_BASE_ALL_VALUES | {
-                                 'function_name': 'apples'
-                             },
-                             ENDPOINT_BASE_REQUIRED_VALUES | {
-                                 'function_name': 'oranges'
-                             }
-                         ],
+@pytest.mark.parametrize("endpoint_kwargs", [ENDPOINT_ALL_VALUES.copy(), ENDPOINT_REQUIRED_VALUES.copy()],
                          ids=["all-values", "required-values"])
 def test_endpoint(endpoint_kwargs: dict):
     _test_model_instantiation(FastApiFrontEndConfig.Endpoint, endpoint_kwargs)
 
 
-@pytest.mark.parametrize("cors_kwargs", [{
-        "allow_origins": ["http://example.com", "https://example.com"],
-        "allow_origin_regex": r"^https?://.*\.example\.com$",
-        "allow_methods": ["GET", "POST"],
-        "allow_headers": ["Content-Type"],
-        "allow_credentials": True,
-        "expose_headers": ["X-Custom-Header"],
-        "max_age": 3600
-    }, {}], ids=["all-values", "required-values"])
+@pytest.mark.parametrize("cors_kwargs", [CORS_ALL_VALUES.copy(), CORS_REQUIRED_VALUES.copy()],
+                         ids=["all-values", "required-values"])
 def test_cross_origin_resource_sharing(cors_kwargs: dict):
     model = _test_model_instantiation(FastApiFrontEndConfig.CrossOriginResourceSharing, cors_kwargs)
 
@@ -84,3 +114,10 @@ def test_cross_origin_resource_sharing(cors_kwargs: dict):
         assert isinstance(model.allow_credentials, bool)
         assert isinstance(model.expose_headers, list)
         assert isinstance(model.max_age, int)
+
+
+@pytest.mark.parametrize(
+    "config_kwargs", [FAST_API_FRONT_END_CONFIG_ALL_VALUES.copy(), FAST_API_FRONT_END_CONFIG_REQUIRES_VALUES.copy()],
+    ids=["all-values", "required-values"])
+def test_fast_api_front_end_config(config_kwargs: dict):
+    model = _test_model_instantiation(FastApiFrontEndConfig, config_kwargs)

--- a/tests/aiq/front_ends/fastapi/test_fastapi_front_end_config.py
+++ b/tests/aiq/front_ends/fastapi/test_fastapi_front_end_config.py
@@ -16,6 +16,7 @@
 import pytest
 from pydantic import BaseModel
 
+from aiq.data_models.step_adaptor import StepAdaptorConfig
 from aiq.front_ends.fastapi.fastapi_front_end_config import FastApiFrontEndConfig
 
 ENDPOINT_BASE_ALL_VALUES = {
@@ -121,3 +122,20 @@ def test_cross_origin_resource_sharing(cors_kwargs: dict):
     ids=["all-values", "required-values"])
 def test_fast_api_front_end_config(config_kwargs: dict):
     model = _test_model_instantiation(FastApiFrontEndConfig, config_kwargs)
+
+    if len(model.model_fields_set) == 0:
+        # Make sure that the defaults appear reasonable
+        assert isinstance(model.root_path, str)
+        assert isinstance(model.host, str)
+        assert isinstance(model.port, int)
+        assert model.port >= 0
+        assert model.port <= 65535
+        assert isinstance(model.reload, bool)
+        assert isinstance(model.workers, int)
+        assert model.workers >= 1
+        assert isinstance(model.step_adaptor, StepAdaptorConfig)
+        assert isinstance(model.workflow, FastApiFrontEndConfig.EndpointBase)
+        assert isinstance(model.endpoints, list)
+        assert isinstance(model.cors, FastApiFrontEndConfig.CrossOriginResourceSharing)
+        assert isinstance(model.use_gunicorn, bool)
+        assert (isinstance(model.runner_class, str) or model.runner_class is None)

--- a/tests/aiq/front_ends/fastapi/test_fastapi_front_end_config.py
+++ b/tests/aiq/front_ends/fastapi/test_fastapi_front_end_config.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from aiq.front_ends.fastapi.fastapi_front_end_config import FastApiFrontEndConfig
+
+ENDPOINT_BASE_ALL_VALUES = {
+    "method": "GET",
+    "description": "all values provided",
+    "path": "/test",
+    "websocket_path": "/ws",
+    "openai_api_path": "/openai"
+}
+
+ENDPOINT_BASE_REQUIRED_VALUES = {"method": "POST", "description": "only required values"}
+
+def _test_model_instantiation(model_class, model_kwargs):
+    """
+    Helper function to test instantiation of a Pydantic model.
+    """
+    model = model_class(**model_kwargs)
+    assert model.model_fields_set == model_kwargs.keys()
+    for (key, value) in model_kwargs.items():
+        assert getattr(model, key) == value
+
+    return model
+
+
+@pytest.mark.parametrize("endpoint_kwargs",
+                         [ENDPOINT_BASE_ALL_VALUES.copy(), ENDPOINT_BASE_REQUIRED_VALUES.copy()],
+                         ids=["all-values", "required-values"])
+def test_endpoint_base(endpoint_kwargs: dict):
+    _test_model_instantiation(FastApiFrontEndConfig.EndpointBase, endpoint_kwargs)
+
+
+def test_endpoint_base_invalid_method():
+    with pytest.raises(ValueError, match=r"validation error for EndpointBase\s+method"):
+        FastApiFrontEndConfig.EndpointBase(method="INVALID", description="test")
+
+
+@pytest.mark.parametrize("endpoint_kwargs",
+                         [
+                             ENDPOINT_BASE_ALL_VALUES | {
+                                 'function_name': 'apples'
+                             },
+                             ENDPOINT_BASE_REQUIRED_VALUES | {
+                                 'function_name': 'oranges'
+                             }
+                         ],
+                         ids=["all-values", "required-values"])
+def test_endpoint(endpoint_kwargs: dict):
+    _test_model_instantiation(FastApiFrontEndConfig.Endpoint, endpoint_kwargs)
+
+
+@pytest.mark.parametrize("cors_kwargs", [{
+        "allow_origins": ["http://example.com", "https://example.com"],
+        "allow_origin_regex": r"^https?://.*\.example\.com$",
+        "allow_methods": ["GET", "POST"],
+        "allow_headers": ["Content-Type"],
+        "allow_credentials": True,
+        "expose_headers": ["X-Custom-Header"],
+        "max_age": 3600
+    }, {}], ids=["all-values", "required-values"])
+def test_cross_origin_resource_sharing(cors_kwargs: dict):
+    model = _test_model_instantiation(FastApiFrontEndConfig.CrossOriginResourceSharing, cors_kwargs)
+
+    if len(model.model_fields_set) == 0:
+        # Make sure that the defaults appear reasonable
+        assert model.allow_methods == ["GET"]
+        assert isinstance(model.allow_headers, list)
+        assert isinstance(model.allow_credentials, bool)
+        assert isinstance(model.expose_headers, list)
+        assert isinstance(model.max_age, int)

--- a/tests/aiq/front_ends/fastapi/test_fastapi_front_end_config.py
+++ b/tests/aiq/front_ends/fastapi/test_fastapi_front_end_config.py
@@ -116,7 +116,6 @@ def test_cross_origin_resource_sharing(cors_kwargs: dict):
         assert isinstance(model.expose_headers, list)
         assert isinstance(model.max_age, int)
 
-
 @pytest.mark.parametrize(
     "config_kwargs", [FAST_API_FRONT_END_CONFIG_ALL_VALUES.copy(), FAST_API_FRONT_END_CONFIG_REQUIRES_VALUES.copy()],
     ids=["all-values", "required-values"])

--- a/tests/aiq/profiler/forecasting/test_model_trainer.py
+++ b/tests/aiq/profiler/forecasting/test_model_trainer.py
@@ -15,7 +15,6 @@
 
 import pytest
 
-from aiq.data_models.intermediate_step import IntermediateStep
 from aiq.profiler.forecasting.model_trainer import ModelTrainer
 from aiq.profiler.forecasting.model_trainer import create_model
 from aiq.profiler.forecasting.models import ForecastingBaseModel
@@ -39,13 +38,15 @@ def test_create_model_invalid_type():
         create_model("unsupported_model")
 
 
-@pytest.mark.parametrize(
-    "model_trainer_kwargs",
-    [
-        {},
-        {"model_type": "linear"},
-        {"model_type": "randomforest"},
-    ])
+@pytest.mark.parametrize("model_trainer_kwargs", [
+    {},
+    {
+        "model_type": "linear"
+    },
+    {
+        "model_type": "randomforest"
+    },
+])
 def test_model_trainer_initialization(model_trainer_kwargs: dict):
     mt = ModelTrainer(**model_trainer_kwargs)
     if "model_type" in model_trainer_kwargs:

--- a/tests/aiq/profiler/forecasting/test_model_trainer.py
+++ b/tests/aiq/profiler/forecasting/test_model_trainer.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from aiq.data_models.intermediate_step import IntermediateStep
+from aiq.profiler.forecasting.model_trainer import ModelTrainer
+from aiq.profiler.forecasting.model_trainer import create_model
+from aiq.profiler.forecasting.models import ForecastingBaseModel
+from aiq.profiler.forecasting.models import LinearModel
+from aiq.profiler.forecasting.models import RandomForestModel
+
+
+@pytest.mark.parametrize(
+    "model_type, expected_model_class",
+    [
+        ("linear", LinearModel),
+        ("randomforest", RandomForestModel),
+    ],
+)
+def test_create_model(model_type: str, expected_model_class: type[ForecastingBaseModel]):
+    assert isinstance(create_model(model_type), expected_model_class)
+
+
+def test_create_model_invalid_type():
+    with pytest.raises(ValueError, match="Unsupported model_type: unsupported_model"):
+        create_model("unsupported_model")
+
+
+@pytest.mark.parametrize(
+    "model_trainer_kwargs",
+    [
+        {},
+        {"model_type": "linear"},
+        {"model_type": "randomforest"},
+    ])
+def test_model_trainer_initialization(model_trainer_kwargs: dict):
+    mt = ModelTrainer(**model_trainer_kwargs)
+    if "model_type" in model_trainer_kwargs:
+        assert mt.model_type == model_trainer_kwargs["model_type"]

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ dev = [
     { name = "pylint", specifier = "==3.3.*" },
     { name = "pytest", specifier = "~=8.3" },
     { name = "pytest-asyncio", specifier = "==0.24.*" },
-    { name = "pytest-cov", specifier = "~=6.0" },
+    { name = "pytest-cov", specifier = "~=6.1" },
     { name = "pytest-httpserver", specifier = "==1.1.*" },
     { name = "python-docx", specifier = "~=1.1.0" },
     { name = "setuptools", specifier = ">=64" },
@@ -4555,15 +4555,15 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "6.0.0"
+version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945 }
+sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949 },
+    { url = "https://files.pythonhosted.org/packages/28/d0/def53b4a790cfb21483016430ed828f64830dd981ebe1089971cd10cab25/pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde", size = 23841 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
* Importing code from `aiq`, and specifically `aiq.runtime.loader` caused the coverage tool to under-report our coverage. I suspect the issue is that either our plugin was being loaded before the coverage plugin, or the coverage plugin explicitly attempts to ignore modules loaded by other plugins. 
* Added a few more tests
* Update to pytest-cov 6.1
* Replace deprecated pydantic validator in `src/aiq/tool/github_tools/get_github_issue.py`

Closes #102

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
