### PR TITLE
Modify JSON serialization to handle non-serializable objects

### DIFF
--- a/src/aiq/eval/dataset_handler/dataset_handler.py
+++ b/src/aiq/eval/dataset_handler/dataset_handler.py
@@ -161,4 +161,4 @@ class DatasetHandler:
             # Unstructured case: return only raw output objects as a JSON array
             data = [json.loads(item.output_obj) for item in eval_input.eval_input_items]
 
-        return json.dumps(data, indent=indent, ensure_ascii=False)
+        return json.dumps(data, indent=indent, ensure_ascii=False, default=str)


### PR DESCRIPTION
Adjusted the `json.dumps` call to include a `default=str` parameter. This ensures that non-serializable objects are converted to strings, preventing potential serialization errors.

## Description
[Closes !103](https://github.com/NVIDIA/AgentIQ/issues/103)

Minor bug in eval dataset handler where not serializable types cannot be written to file without a default conversion method.

Defaulting to string 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
