### PR TITLE
Upload nightly builds and release builds to pypi

### DIFF
--- a/ci/scripts/gitlab/artifactory_upload.sh
+++ b/ci/scripts/gitlab/artifactory_upload.sh
@@ -19,7 +19,11 @@ set -e
 
 # change this to ready to publish. this should be done programmatically once
 # the release process is finalized.
-RELEASE_STATUS=preview
+if [[ "${CI_CRON_NIGHTLY}" == "true" || "${CI_COMMIT_BRANCH}" == "main" ]]; then
+    RELEASE_STATUS=ready
+else
+    RELEASE_STATUS=preview
+fi
 
 # Define variables
 AIQ_ARCH="any"


### PR DESCRIPTION
## Description
* Update the `ci/scripts/gitlab/artifactory_upload.sh` script to conditionally set `RELEASE_STATUS=ready` when being run from a scheduled pipeline or if being run from the main branch.


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
