### PR TITLE
Ensure the nightly builds have a unique alpha version number

### DIFF
--- a/ci/scripts/gitlab/artifactory_upload.sh
+++ b/ci/scripts/gitlab/artifactory_upload.sh
@@ -19,7 +19,11 @@ set -e
 
 # change this to ready to publish. this should be done programmatically once
 # the release process is finalized.
-RELEASE_STATUS=preview
+if [[ "${CI_CRON_NIGHTLY}" == "true" || "${CI_COMMIT_BRANCH}" == "main" ]]; then
+    RELEASE_STATUS=ready
+else
+    RELEASE_STATUS=preview
+fi
 
 # Define variables
 AIQ_ARCH="any"

--- a/ci/scripts/gitlab/artifactory_upload.sh
+++ b/ci/scripts/gitlab/artifactory_upload.sh
@@ -77,11 +77,8 @@ function install_jfrog_cli() {
 }
 install_jfrog_cli
 
-function get_git_tag() {
-    # Get the latest Git tag, sorted by version, excluding lightweight tags
-    git describe --tags --abbrev=0 2>/dev/null || echo "no-tag"
-}
 GIT_TAG=$(get_git_tag)
+rapids-logger "Git Version: ${GIT_TAG}"
 
 # Upload wheels if enabled
 if [[ "${UPLOAD_TO_ARTIFACTORY}" == "true" ]]; then

--- a/ci/scripts/gitlab/build_wheel.sh
+++ b/ci/scripts/gitlab/build_wheel.sh
@@ -21,17 +21,10 @@ GITLAB_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd 
 source ${GITLAB_SCRIPT_DIR}/common.sh
 WHEELS_DIR=${CI_PROJECT_DIR}/.tmp/wheels
 
-rapids-logger "Git Version: $(git describe)"
-
 create_env extra:all
 
-
-function get_git_tag() {
-    # Get the latest Git tag, sorted by version, excluding lightweight tags
-    git describe --tags --abbrev=0 2>/dev/null || echo "no-tag"
-}
 GIT_TAG=$(get_git_tag)
-
+rapids-logger "Git Version: ${GIT_TAG}"
 
 function build_wheel() {
     rapids-logger "Building Wheel for $1"


### PR DESCRIPTION
## Description
* Creates a unique tag based on the date

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
