### PR TITLE
Use setuptools_scm environment variables to set the version

### DIFF
--- a/ci/scripts/gitlab/artifactory_upload.sh
+++ b/ci/scripts/gitlab/artifactory_upload.sh
@@ -23,7 +23,7 @@ source ${GITLAB_SCRIPT_DIR}/common.sh
 
 # change this to ready to publish. this should be done programmatically once
 # the release process is finalized.
-if [[ "${CI_CRON_NIGHTLY}" == "true" || "${CI_COMMIT_BRANCH}" == "main" ]]; then
+if [[ "${CI_CRON_NIGHTLY}" == "1" || "${CI_COMMIT_BRANCH}" == "main" ]]; then
     RELEASE_STATUS=ready
 else
     RELEASE_STATUS=preview

--- a/ci/scripts/gitlab/build_wheel.sh
+++ b/ci/scripts/gitlab/build_wheel.sh
@@ -21,6 +21,7 @@ GITLAB_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd 
 source ${GITLAB_SCRIPT_DIR}/common.sh
 
 GIT_TAG=$(get_git_tag)
+export SETUPTOOLS_SCM_PRETEND_VERSION="${GIT_TAG}"
 rapids-logger "Git Version: ${GIT_TAG}"
 
 WHEELS_DIR=${CI_PROJECT_DIR}/.tmp/wheels

--- a/ci/scripts/gitlab/common.sh
+++ b/ci/scripts/gitlab/common.sh
@@ -39,7 +39,6 @@ function get_git_tag() {
         # Note: We are intentionally not pushing this tag, it exists for the sole purpose of generating a
         # unique alpha version for nightly builds.
         GIT_TAG=$(echo $GIT_TAG | sed -e "s|-dev|a$(date +"%Y%m%d")|")
-        git tag -am ${GIT_TAG} "${GIT_TAG}"
     fi
 
     echo ${GIT_TAG}


### PR DESCRIPTION
* Use the SETUPTOOLS_SCM_PRETEND_VERSION env variable rather than attempting to create a temporary tag

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
