### PR TITLE
Rename Otelcollector to otlp

### DIFF
--- a/docs/source/concepts/observability.md
+++ b/docs/source/concepts/observability.md
@@ -20,7 +20,7 @@ limitations under the License.
 The AgentIQ Observability Module provides support for configurable telemetry setup to do logging tracing and metrics for AgentIQ workflows.
 - Enables users to configure telemetry options from a predefined list based on their preferences.
 - Listens real-time usage statistics pushed by `IntermediateStepManager`.
-- Translates the usage statistics to OpenTelemetry format and push to the configured provider/method. (e.g., phoenix, OTelCollector, console, file)
+- Translates the usage statistics to OpenTelemetry format and push to the configured provider/method. (e.g., phoenix, otlp, console, file)
 
 These features enable AgentIQ developers to test their workflows locally and integrate observability seamlessly.
 

--- a/src/aiq/observability/register.py
+++ b/src/aiq/observability/register.py
@@ -47,15 +47,15 @@ async def phoenix_telemetry_exporter(config: PhoenixTelemetryExporter, builder: 
         logger.error("Error in Phoenix telemetry Exporter\n %s", ex, exc_info=True)
 
 
-class OtelCollectorTelemetryExporter(TelemetryExporterBaseConfig, name="otelcollector"):
-    """A telemetry exporter to transmit traces to externally hosted otel collector service."""
+class OtlpTelemetryExporter(TelemetryExporterBaseConfig, name="otlp"):
+    """A telemetry exporter to transmit traces to externally hosted otlp service."""
 
     endpoint: str = Field(description="The otel endpoint to export telemetry traces.")
     project: str = Field(description="The project name to group the telemetry traces.")
 
 
-@register_telemetry_exporter(config_type=OtelCollectorTelemetryExporter)
-async def otel_telemetry_exporter(config: OtelCollectorTelemetryExporter, builder: Builder):
+@register_telemetry_exporter(config_type=OtlpTelemetryExporter)
+async def otlp_telemetry_exporter(config: OtlpTelemetryExporter, builder: Builder):
 
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 


### PR DESCRIPTION
## Description
This PR is to rename 'otelcollector' object to otlp which is more relevant for the use case. This object can be used with any telemetry exporter like datadog, zipkin etc. OtelCollector has a different meaning and functionality and that needs its own configuration file to be specified. Using otlp directly is more simpler.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
