### PR TITLE
Make kwargs optional to the eval output customizer scripts

### DIFF
--- a/docs/source/concepts/evaluate.md
+++ b/docs/source/concepts/evaluate.md
@@ -331,8 +331,9 @@ eval:
         convert_workflow_to_csv:
           script: examples/simple/src/aiq_simple/scripts/workflow_to_csv.py
           kwargs:
-            input: ./.tmp/aiq/examples/simple_output/workflow_output.json
-            output: ./.tmp/aiq/examples/simple_output/workflow.csv
+            # The input and output are relative to the output directory
+            input: workflow_output.json
+            output: workflow.csv
 ```
 
 ## Remote Storage

--- a/examples/simple/src/aiq_simple/scripts/workflow_to_csv.py
+++ b/examples/simple/src/aiq_simple/scripts/workflow_to_csv.py
@@ -57,8 +57,8 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Convert workflow_output.json to workflow.csv")
     # output_dir is a mandatory first argument
     parser.add_argument("--output_dir", type=Path, required=True, help="Path to output directory")
-    parser.add_argument("--input", type=Path, required=True, help="Path to workflow_output.json")
-    parser.add_argument("--output", type=Path, required=True, help="Path to output CSV")
+    parser.add_argument("--input", type=Path, default="workflow_output.json", help="Path to workflow_output.json")
+    parser.add_argument("--output", type=Path, default="workflow.csv", help="Path to output CSV")
     return parser.parse_args()
 
 

--- a/src/aiq/data_models/evaluate.py
+++ b/src/aiq/data_models/evaluate.py
@@ -31,7 +31,7 @@ class EvalCustomScriptConfig(BaseModel):
     # Path to the script to run
     script: Path
     # Keyword arguments to pass to the script
-    kwargs: dict[str, str]
+    kwargs: dict[str, str] = {}
 
 
 class EvalOutputConfig(BaseModel):


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This pull request makes the keyword arguments for the evaluation output customizer scripts optional, allowing users to omit them. Key changes include:

Updating EvalCustomScriptConfig in evaluate.py to set a default empty dictionary for kwargs.
Changing the workflow_to_csv.py script’s argument parser to use default values for input and output paths.
Revising the documentation to reflect the new usage and relative paths.
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
