### PR TITLE
Add nicer error message for agents without tools

### DIFF
--- a/src/aiq/agent/react_agent/register.py
+++ b/src/aiq/agent/react_agent/register.py
@@ -92,6 +92,8 @@ async def react_agent_workflow(config: ReActAgentWorkflowConfig, builder: Builde
     # the agent can run any installed tool, simply install the tool and add it to the config file
     # the sample tool provided can easily be copied or changed
     tools = builder.get_tools(tool_names=config.tool_names, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+    if not tools:
+        raise ValueError(f"No tools specified for ReAct Agent '{config.llm_name}'")
     # configure callbacks, for sending intermediate steps
     # construct the ReAct Agent Graph from the configured llm, prompt, and tools
     graph: CompiledGraph = await ReActAgentGraph(llm=llm,

--- a/src/aiq/agent/rewoo_agent/register.py
+++ b/src/aiq/agent/rewoo_agent/register.py
@@ -106,6 +106,8 @@ async def ReWOO_agent_workflow(config: ReWOOAgentWorkflowConfig, builder: Builde
     # the agent can run any installed tool, simply install the tool and add it to the config file
     # the sample tool provided can easily be copied or changed
     tools = builder.get_tools(tool_names=config.tool_names, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+    if not tools:
+        raise ValueError(f"No tools specified for ReWOO Agent '{config.llm_name}'")
 
     # construct the ReWOO Agent Graph from the configured llm, prompt, and tools
     graph: CompiledGraph = await ReWOOAgentGraph(llm=llm,

--- a/src/aiq/agent/tool_calling_agent/register.py
+++ b/src/aiq/agent/tool_calling_agent/register.py
@@ -57,6 +57,8 @@ async def tool_calling_agent_workflow(config: ToolCallAgentWorkflowConfig, build
     # the agent can run any installed tool, simply install the tool and add it to the config file
     # the sample tools provided can easily be copied or changed
     tools = builder.get_tools(tool_names=config.tool_names, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+    if not tools:
+        raise ValueError(f"No tools specified for Tool Calling Agent '{config.llm_name}'")
 
     # some LLMs support tool calling
     # these models accept the tool's input schema and decide when to use a tool based on the input's relevance


### PR DESCRIPTION
## Description
Adds a check for empty tools being used in agent configs. If we don't find any tools, raises an exception with the name of the llm in question to make debugging easier. Sample output:

```
aiq run --config_file workflow.yaml --input foo.msg
[...]
ValueError: No tools specified for ReAct Agent 'email_extraction_llm'
Error: No tools specified for ReAct Agent 'email_extraction_llm'
```

Closes #145 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
