### PR TITLE
Group wheels under a common `aiqtoolkit` directory

### DIFF
--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -19,7 +19,7 @@ set -e
 GITHUB_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 source ${GITHUB_SCRIPT_DIR}/common.sh
-WHEELS_DIR=${WORKSPACE_TMP}/wheels
+WHEELS_DIR=${WORKSPACE_TMP}/wheels/aiqtoolkit
 
 create_env extra:all
 

--- a/ci/scripts/gitlab/artifactory_upload.sh
+++ b/ci/scripts/gitlab/artifactory_upload.sh
@@ -34,7 +34,8 @@ AIQ_ARCH="any"
 AIQ_OS="any"
 AIQ_COMPONENT_NAME="aiqtoolkit"
 
-WHEELS_DIR="${CI_PROJECT_DIR}/.tmp/wheels/${AIQ_COMPONENT_NAME}"
+WHEELS_BASE_DIR="${CI_PROJECT_DIR}/.tmp/wheels"
+WHEELS_DIR="${WHEELS_BASE_DIR}/${AIQ_COMPONENT_NAME}"
 # Define the subdirectories to be exclude
 EXCLUDE_SUBDIRS=("examples")
 
@@ -99,7 +100,7 @@ if [[ "${UPLOAD_TO_ARTIFACTORY}" == "true" ]]; then
         # Find all .whl files in the current subdirectory (no depth limit)
         find "${SUBDIR}" -type f -name "*.whl" | while read -r WHEEL_FILE; do
             # Extract relative path to preserve directory structure
-            RELATIVE_PATH="${WHEEL_FILE#${WHEELS_DIR}/}"
+            RELATIVE_PATH="${WHEEL_FILE#${WHEELS_BASE_DIR}/}"
             ARTIFACTORY_PATH="${AIQ_ARTIFACTORY_NAME}/${RELATIVE_PATH}"
 
             echo "Uploading ${WHEEL_FILE} to ${ARTIFACTORY_PATH}..."

--- a/ci/scripts/gitlab/artifactory_upload.sh
+++ b/ci/scripts/gitlab/artifactory_upload.sh
@@ -34,7 +34,7 @@ AIQ_ARCH="any"
 AIQ_OS="any"
 AIQ_COMPONENT_NAME="aiqtoolkit"
 
-WHEELS_DIR="${CI_PROJECT_DIR}/.tmp/wheels"
+WHEELS_DIR="${CI_PROJECT_DIR}/.tmp/wheels/${AIQ_COMPONENT_NAME}"
 # Define the subdirectories to be exclude
 EXCLUDE_SUBDIRS=("examples")
 

--- a/ci/scripts/gitlab/build_wheel.sh
+++ b/ci/scripts/gitlab/build_wheel.sh
@@ -28,7 +28,7 @@ if [[ "${CI_CRON_NIGHTLY}" == "1" ]]; then
 fi
 
 
-WHEELS_DIR=${CI_PROJECT_DIR}/.tmp/wheels
+WHEELS_DIR=${CI_PROJECT_DIR}/.tmp/wheels/aiqtoolkit
 
 create_env extra:all
 


### PR DESCRIPTION

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AgentIQ/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
